### PR TITLE
Use friendlier completion names

### DIFF
--- a/counsel-osx-app.el
+++ b/counsel-osx-app.el
@@ -39,7 +39,7 @@
 (require 'ivy)
 
 (defvar counsel-osx-app-location "/Applications"
-  "Path to directory containing applications.")
+  "Path (or list of paths) to directories containing applications.")
 
 (defvar counsel-osx-app-pattern "*.app"
   "Pattern for applications in `counsel-osx-app-location'.
@@ -66,7 +66,8 @@ argument and returns command.")
                           (file-expand-wildcards
                            (concat path "/" counsel-osx-app-pattern)))
                         locs)))
-    (apply #'append files)))
+    (mapcar (lambda (path) (cons (file-name-base path) path))
+            (apply #'append files))))
 
 (defun counsel-osx-app-action-default (app)
   "Launch APP using `counsel-osx-app-launch-cmd'."
@@ -96,16 +97,20 @@ argument and returns command.")
            (user-error "Could not construct cmd from `counsel-osx-app-launch-cmd'"))))
       (user-error "Cancelled"))))
 
+(defmacro counsel-osx-app--use-cdr (f)
+  "Return a function that operates on the cdr of its argument instead."
+  `(lambda (cons-cell) (,f (cdr cons-cell))))
+
 (ivy-set-actions
  'counsel-osx-app
- '(("f" counsel-osx-app-action-file "run on a file")))
+ `(("f" ,(counsel-osx-app--use-cdr counsel-osx-app-action-file) "run on a file")))
 
 ;;;###autoload
 (defun counsel-osx-app ()
   "Launch an application via ivy interface."
   (interactive)
   (ivy-read "Run application: " (counsel-osx-app-list)
-            :action #'counsel-osx-app-action-default
+            :action (counsel-osx-app--use-cdr counsel-osx-app-action-default)
             :caller 'counsel-app))
 
 (provide 'counsel-osx-app)


### PR DESCRIPTION
Use an alist with `ivy-read` to pair a readable string (for completion) with the actual value of the item. This stops completing on very common pieces like `/Applications/`.
